### PR TITLE
v1.3.1: Fix English log spam + update zh-CN to 47.5K entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # SunHavenLocalization
 
-用于完善 太阳港 的多国语言翻译插件.
+用于完善 太阳港 的多国语言翻译插件. 基于xiaoye97版本开发。
+https://github.com/xiaoye97/SunHavenLocalization
 
-由于太阳港的官方中文全是粗糙的机器翻译, 所以我制作了这个插件, 用来修改翻译.
+由于太阳港的官方中文全是粗糙的机器翻译, 所以fork了xiaoye97的初版插件, 用来修改翻译.
 
 这个插件不止可以修改中文的翻译, 其他所有语言也都可以.
 

--- a/SunHavenLocalization/CommonTool.cs
+++ b/SunHavenLocalization/CommonTool.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.Globalization;
 using System.IO.Compression;
 using System.Runtime.Serialization.Formatters.Binary;
+using I2.Loc;
+using UnityEngine;
 
 namespace SunHavenLocalization
 {
@@ -27,6 +29,38 @@ namespace SunHavenLocalization
                 Console.WriteLine($"字符串转换时间出错:[{str}]，异常信息：\n{e}");
                 return DateTime.MinValue;
             }
+        }
+
+        /// <summary>
+        /// 查找所有 LanguageSourceData，兼容 LanguageSourceAsset 和 LanguageSource。
+        /// 优先搜索 LanguageSourceAsset（ScriptableObject），找不到则回退到 LanguageSource（MonoBehaviour）。
+        /// </summary>
+        public static LanguageSourceData[] FindAllSourceData()
+        {
+            // 优先尝试 LanguageSourceAsset
+            var sourceAssets = Resources.FindObjectsOfTypeAll<LanguageSourceAsset>();
+            if (sourceAssets.Length > 0)
+            {
+                SunHavenLocalizationPlugin.LogInfo($"[FindAllSourceData] Found {sourceAssets.Length} LanguageSourceAsset(s).");
+                var result = new LanguageSourceData[sourceAssets.Length];
+                for (int i = 0; i < sourceAssets.Length; i++)
+                    result[i] = sourceAssets[i].SourceData;
+                return result;
+            }
+
+            // 回退：尝试 LanguageSource（MonoBehaviour）
+            var sources = Resources.FindObjectsOfTypeAll<LanguageSource>();
+            if (sources.Length > 0)
+            {
+                SunHavenLocalizationPlugin.LogInfo($"[FindAllSourceData] Found {sources.Length} LanguageSource(s) (fallback).");
+                var result = new LanguageSourceData[sources.Length];
+                for (int i = 0; i < sources.Length; i++)
+                    result[i] = sources[i].SourceData;
+                return result;
+            }
+
+            SunHavenLocalizationPlugin.LogWarning("[FindAllSourceData] No LanguageSourceAsset or LanguageSource found.");
+            return new LanguageSourceData[0];
         }
 
         public static void SaveLocSheet(string path, LocSheet sheet)

--- a/SunHavenLocalization/DumpTool.cs
+++ b/SunHavenLocalization/DumpTool.cs
@@ -1,4 +1,4 @@
-﻿using BepInEx;
+using BepInEx;
 using I2.Loc;
 using System;
 using System.Collections.Generic;
@@ -13,34 +13,65 @@ namespace SunHavenLocalization
         public static void DumpAll()
         {
             DateTime now = DateTime.Now;
-            var sourceAssets = Resources.FindObjectsOfTypeAll<LanguageSourceAsset>();
+            SunHavenLocalizationPlugin.LogInfo("[DumpAll] Starting dump...");
+
+            var sourceDataArray = CommonTool.FindAllSourceData();
+            SunHavenLocalizationPlugin.LogInfo($"[DumpAll] Found {sourceDataArray.Length} source(s).");
+
+            if (sourceDataArray.Length == 0)
+            {
+                SunHavenLocalizationPlugin.LogError("[DumpAll] No LanguageSourceAsset or LanguageSource found! Localization data may not be loaded yet.");
+                return;
+            }
+
+            // Log each source
+            for (int i = 0; i < sourceDataArray.Length; i++)
+            {
+                var sd = sourceDataArray[i];
+                int termCount = sd != null ? sd.mTerms.Count : 0;
+                int langCount = sd != null ? sd.mLanguages.Count : 0;
+                SunHavenLocalizationPlugin.LogInfo($"[DumpAll]   Source[{i}]: terms={termCount}, languages={langCount}");
+            }
+
             LocStorage lastStorage = null;
             if (SunHavenLocalizationPlugin.LoadedLocStorage != null)
             {
                 lastStorage = SunHavenLocalizationPlugin.LoadedLocStorage;
+                SunHavenLocalizationPlugin.LogInfo("[DumpAll] Using existing LoadedLocStorage.");
             }
             else
             {
+                SunHavenLocalizationPlugin.LogInfo("[DumpAll] No existing LoadedLocStorage, initializing new one...");
                 lastStorage = new LocStorage();
-                InitStorage(sourceAssets[0].SourceData, lastStorage);
+                InitStorage(sourceDataArray[0], lastStorage);
             }
+
             LocStorage newStorage = new LocStorage();
-            InitStorage(sourceAssets[0].SourceData, newStorage);
-            List<string> newKeyList = new List<string>();
-            foreach (LanguageSourceAsset sourceAsset in sourceAssets)
+            InitStorage(sourceDataArray[0], newStorage);
+            SunHavenLocalizationPlugin.LogInfo($"[DumpAll] New storage initialized with {newStorage.Storage.Count} languages.");
+
+            // Log language list
+            foreach (var kv in newStorage.Storage)
             {
-                // 一个特殊处理，quest表的22个语言，而其他表是21个语言，删除quest表的第一个语言
-                if (sourceAsset.SourceData.mLanguages.Count > sourceAssets[0].SourceData.mLanguages.Count)
+                SunHavenLocalizationPlugin.LogInfo($"[DumpAll]   Language: {kv.Key} (index={kv.Value.LanguageIndex})");
+            }
+
+            List<string> newKeyList = new List<string>();
+            foreach (var sourceData in sourceDataArray)
+            {
+                // Special handling: quest table has 22 languages, others have 21
+                if (sourceData.mLanguages.Count > sourceDataArray[0].mLanguages.Count)
                 {
-                    sourceAsset.SourceData.mLanguages.RemoveAt(0);
-                    foreach (var term in sourceAsset.SourceData.mTerms)
+                    SunHavenLocalizationPlugin.LogWarning($"[DumpAll] Source has {sourceData.mLanguages.Count} languages (expected {sourceDataArray[0].mLanguages.Count}). Removing first language.");
+                    sourceData.mLanguages.RemoveAt(0);
+                    foreach (var term in sourceData.mTerms)
                     {
                         var newList = term.Languages.ToList();
                         newList.RemoveAt(0);
                         term.Languages = newList.ToArray();
                     }
                 }
-                foreach (var term in sourceAsset.SourceData.mTerms)
+                foreach (var term in sourceData.mTerms)
                 {
                     if (term.TermType == eTermType.Text)
                     {
@@ -48,11 +79,18 @@ namespace SunHavenLocalization
                     }
                 }
             }
+            SunHavenLocalizationPlugin.LogInfo($"[DumpAll] Total text terms across all sources: {newKeyList.Count}");
 
-            // 复制老表到新表, 并统计老表中被移除的条目, 将这些条目标记为移除
+            // Copy old entries and mark removed ones
+            int removedCount = 0;
             foreach (var sheetKV in lastStorage.Storage)
             {
                 var lastSheet = sheetKV.Value;
+                if (!newStorage.Storage.ContainsKey(sheetKV.Key))
+                {
+                    SunHavenLocalizationPlugin.LogWarning($"[DumpAll] Language '{sheetKV.Key}' not found in new storage, skipping.");
+                    continue;
+                }
                 var newSheet = newStorage.Storage[sheetKV.Key];
                 newSheet.Version = lastSheet.Version;
                 foreach (var kv in lastSheet.Dict)
@@ -64,18 +102,24 @@ namespace SunHavenLocalization
                         {
                             item.UpdateMode = UpdateMode.Remove;
                             item.UpdateTime = now;
+                            removedCount++;
                         }
                     }
                     newSheet.Dict[kv.Key] = item;
                 }
             }
-            // 添加新的条目和更新老条目内容
-            foreach (LanguageSourceAsset sourceAsset in sourceAssets)
+            SunHavenLocalizationPlugin.LogInfo($"[DumpAll] Marked {removedCount} entries as removed.");
+
+            // Add new entries and update existing ones
+            int newCount = 0;
+            int updatedCount = 0;
+            foreach (var sourceData in sourceDataArray)
             {
-                int termCount = sourceAsset.SourceData.mTerms.Count;
+                int termCount = sourceData.mTerms.Count;
+                SunHavenLocalizationPlugin.LogInfo($"[DumpAll] Processing source ({termCount} terms)...");
                 for (int i = 0; i < termCount; i++)
                 {
-                    var term = sourceAsset.SourceData.mTerms[i];
+                    var term = sourceData.mTerms[i];
                     if (term.TermType == eTermType.Text)
                     {
                         string key = term.Term;
@@ -87,18 +131,14 @@ namespace SunHavenLocalization
                                 string oriTranslation = term.Languages[langIndex];
                                 string langName = newStorage.IndexLangNameDict[langIndex];
                                 LocSheet newSheet = newStorage.Storage[langName];
-                                // 如果表里有此条目, 则检查是否更新了
                                 if (newSheet.Dict.ContainsKey(key))
                                 {
                                     var item = newSheet.Dict[key];
-                                    item.Table = sourceAsset.name;
-                                    // 如果条目没有更新, 则将更新类型置为空
                                     if (item.Original == ori)
                                     {
                                         item.UpdateMode = UpdateMode.None;
                                         item.OriginalUpdateNote = "";
                                     }
-                                    // 如果条目有更新, 则将更新类型置为更新
                                     else
                                     {
                                         item.OriginalUpdateNote = $"[{CommonTool.TimeToString(item.UpdateTime)}]{item.Original}\n[{CommonTool.TimeToString(now)}]{ori}";
@@ -106,9 +146,9 @@ namespace SunHavenLocalization
                                         item.OriginalTranslation = oriTranslation;
                                         item.UpdateTime = now;
                                         item.UpdateMode = UpdateMode.Update;
+                                        updatedCount++;
                                     }
                                 }
-                                // 如果表里没有此条目, 则新增
                                 else
                                 {
                                     LocItem item = new LocItem()
@@ -118,17 +158,18 @@ namespace SunHavenLocalization
                                         OriginalTranslation = oriTranslation,
                                         UpdateTime = now,
                                         UpdateMode = UpdateMode.New,
-                                        Table = sourceAsset.name
                                     };
                                     newSheet.Dict[key] = item;
+                                    newCount++;
                                 }
                             }
                         }
                     }
                 }
             }
+            SunHavenLocalizationPlugin.LogInfo($"[DumpAll] New entries: {newCount}, Updated entries: {updatedCount}");
 
-            // 更新统计信息
+            // Update statistics
             foreach (var sheetKV in newStorage.Storage)
             {
                 var sheet = sheetKV.Value;
@@ -145,8 +186,11 @@ namespace SunHavenLocalization
                     }
                 }
                 sheet.OriginalCharCount = charCount;
+                SunHavenLocalizationPlugin.LogInfo($"[DumpAll]   {sheetKV.Key}: {sheet.LineCount} entries, {charCount} chars");
             }
+
             SaveLocStorage(newStorage);
+            SunHavenLocalizationPlugin.LogInfo("[DumpAll] Dump complete!");
         }
 
         public static void SaveLocStorage(LocStorage locStorage)
@@ -156,6 +200,7 @@ namespace SunHavenLocalization
             if (!directory.Exists)
             {
                 directory.Create();
+                SunHavenLocalizationPlugin.LogInfo($"[SaveLocStorage] Created directory: {saveDir}");
             }
             foreach (var sheetKV in locStorage.Storage)
             {
@@ -169,11 +214,11 @@ namespace SunHavenLocalization
             try
             {
                 CommonTool.SaveLocSheet(path, sheet);
-                SunHavenLocalizationPlugin.LogInfo($"saved {path}");
+                SunHavenLocalizationPlugin.LogInfo($"[SaveLocSheet] Saved {path} ({sheet.Dict.Count} entries)");
             }
             catch (Exception ex)
             {
-                SunHavenLocalizationPlugin.LogError($"Exception when save {path}:\n{ex}");
+                SunHavenLocalizationPlugin.LogError($"[SaveLocSheet] Exception when save {path}:\n{ex}");
             }
         }
 

--- a/SunHavenLocalization/LoadTool.cs
+++ b/SunHavenLocalization/LoadTool.cs
@@ -1,8 +1,8 @@
-﻿using BepInEx;
+using BepInEx;
 using I2.Loc;
 using System.IO;
-using UnityEngine;
 using System;
+using UnityEngine;
 
 namespace SunHavenLocalization
 {
@@ -10,19 +10,42 @@ namespace SunHavenLocalization
     {
         public static void LoadAll()
         {
-            var sourceAssets = Resources.FindObjectsOfTypeAll<LanguageSourceAsset>();
+            SunHavenLocalizationPlugin.LogInfo("[LoadAll] Starting load...");
+
+            var sourceDataArray = CommonTool.FindAllSourceData();
+            SunHavenLocalizationPlugin.LogInfo($"[LoadAll] Found {sourceDataArray.Length} source(s).");
+
+            if (sourceDataArray.Length == 0)
+            {
+                SunHavenLocalizationPlugin.LogError("[LoadAll] No LanguageSourceAsset or LanguageSource found!");
+                return;
+            }
+
             LocStorage storage = new LocStorage();
-            DumpTool.InitStorage(sourceAssets[0].SourceData, storage);
+            DumpTool.InitStorage(sourceDataArray[0], storage);
+            SunHavenLocalizationPlugin.LogInfo($"[LoadAll] Initialized storage with {storage.Storage.Count} languages.");
+
             string saveDir = Paths.PluginPath + "/SunHavenLocalization/datas";
+            SunHavenLocalizationPlugin.LogInfo($"[LoadAll] Looking for xyloc files in: {saveDir}");
+
             DirectoryInfo directory = new DirectoryInfo(saveDir);
             if (!directory.Exists)
             {
+                SunHavenLocalizationPlugin.LogWarning($"[LoadAll] Directory does not exist: {saveDir}");
                 directory.Create();
+                SunHavenLocalizationPlugin.LogInfo($"[LoadAll] Created directory: {saveDir}");
+                SunHavenLocalizationPlugin.LoadedLocStorage = storage;
+                return;
             }
+
             var files = directory.GetFiles("*.xyloc");
+            SunHavenLocalizationPlugin.LogInfo($"[LoadAll] Found {files.Length} xyloc file(s).");
+
             foreach (var file in files)
             {
                 string langName = file.Name.Replace(".xyloc", "");
+                SunHavenLocalizationPlugin.LogInfo($"[LoadAll] Loading {file.Name} (language: {langName})...");
+
                 if (storage.Storage.ContainsKey(langName))
                 {
                     try
@@ -31,20 +54,26 @@ namespace SunHavenLocalization
                         if (sheet != null)
                         {
                             storage.Storage[langName] = sheet;
-                            SunHavenLocalizationPlugin.LogInfo($"loaded language {file.Name}");
+                            SunHavenLocalizationPlugin.LogInfo($"[LoadAll]   Loaded {sheet.Dict.Count} entries for {langName}.");
                         }
                         else
                         {
-                            SunHavenLocalizationPlugin.LogError($"load language {file.Name} fail");
+                            SunHavenLocalizationPlugin.LogError($"[LoadAll]   Failed to load {file.Name} (returned null).");
                         }
                     }
                     catch (Exception ex)
                     {
-                        SunHavenLocalizationPlugin.LogError($"Exception when load language {file.Name}:\n{ex}");
+                        SunHavenLocalizationPlugin.LogError($"[LoadAll]   Exception when loading {file.Name}:\n{ex}");
                     }
                 }
+                else
+                {
+                    SunHavenLocalizationPlugin.LogWarning($"[LoadAll]   Language '{langName}' not found in game's language list, skipping.");
+                }
             }
+
             SunHavenLocalizationPlugin.LoadedLocStorage = storage;
+            SunHavenLocalizationPlugin.LogInfo("[LoadAll] Load complete.");
         }
     }
 }

--- a/SunHavenLocalization/Properties/AssemblyInfo.cs
+++ b/SunHavenLocalization/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 //可以指定所有这些值，也可以使用“生成号”和“修订号”的默认值
 //通过使用 "*"，如下所示:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.0.0")]

--- a/SunHavenLocalization/SunHavenLocalizationPlugin.cs
+++ b/SunHavenLocalization/SunHavenLocalizationPlugin.cs
@@ -1,14 +1,16 @@
-﻿using BepInEx;
+using BepInEx;
 using BepInEx.Configuration;
 using BepInEx.Logging;
 using HarmonyLib;
 using I2.Loc;
+using System;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace SunHavenLocalization
 {
-    [BepInPlugin("xiaoye97.SunHavenLocalization", "SunHavenLocalization", "1.2.0")]
+    [BepInPlugin("xiaoye97.SunHavenLocalization", "SunHavenLocalization", "1.3.1")]
     public class SunHavenLocalizationPlugin : BaseUnityPlugin
     {
         public static SunHavenLocalizationPlugin Instance;
@@ -25,6 +27,11 @@ namespace SunHavenLocalization
         public static List<string> SuccKeys = new List<string>();
         public static List<string> FailKeys = new List<string>();
 
+        // 防重复加载：标记当前场景是否已尝试过 LoadAll
+        private static bool _loadAttemptedThisScene = false;
+        // 标记是否已成功加载
+        private static bool _loadSucceeded = false;
+
         public void Start()
         {
             Instance = this;
@@ -35,24 +42,94 @@ namespace SunHavenLocalization
             LogGetTranslationFailCall = Config.Bind<bool>("dev", "LogGetTranslationFailCall", true, "Log LocalizationManager.GetTranslation fail call");
             AllowMultipleTimesLogGetTranslationSuccCall = Config.Bind<bool>("dev", "AllowMultipleTimesLogGetTranslationSuccCall", false);
             AllowMultipleTimesLogGetTranslationFailCall = Config.Bind<bool>("dev", "AllowMultipleTimesLogGetTranslationFailCall", false);
-            LogInfo("SunHavenLocalization Loaded.");
-            Harmony.CreateAndPatchAll(typeof(SunHavenLocalizationPlugin));
+            LogInfo("=== SunHavenLocalization v1.3.1 Loading ===");
+            try
+            {
+                Harmony.CreateAndPatchAll(typeof(SunHavenLocalizationPlugin));
+                LogInfo("Harmony patches applied successfully.");
+            }
+            catch (Exception ex)
+            {
+                LogError($"Failed to apply Harmony patches: {ex}");
+            }
+
+            // 注册场景加载回调，每次场景加载完后重置标记并尝试加载
+            SceneManager.sceneLoaded += OnSceneLoaded;
+
             Credits.ShowCredits();
+            LogInfo("=== SunHavenLocalization v1.3.1 Loaded ===");
+        }
+
+        /// <summary>
+        /// 场景加载完成时回调。重置标记并尝试加载翻译数据。
+        /// </summary>
+        private static void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+        {
+            LogInfo($"[OnSceneLoaded] Scene loaded: {scene.name}");
+            _loadAttemptedThisScene = false;
+
+            if (!_loadSucceeded)
+            {
+                // 延迟一帧尝试加载，确保场景对象都初始化完毕
+                Instance?.StartCoroutine(DelayedLoadAll());
+            }
+        }
+
+        private static System.Collections.IEnumerator DelayedLoadAll()
+        {
+            // 等两帧，让场景内的对象完成初始化
+            yield return null;
+            yield return null;
+
+            if (!_loadSucceeded && LoadedLocStorage == null)
+            {
+                LogInfo("[DelayedLoadAll] Attempting load after scene transition...");
+                LoadTool.LoadAll();
+                if (LoadedLocStorage != null)
+                {
+                    _loadSucceeded = true;
+                    LogInfo("[DelayedLoadAll] Load succeeded!");
+                }
+                else
+                {
+                    _loadAttemptedThisScene = true;
+                    LogInfo("[DelayedLoadAll] Load failed, will retry on next scene.");
+                }
+            }
         }
 
         public void Update()
         {
             if (Input.GetKey(KeyCode.LeftControl) && Input.GetKey(DumpHotkey.Value))
             {
-                DumpTool.DumpAll();
+                LogInfo("Ctrl+F9 detected, starting DumpAll...");
+                try
+                {
+                    DumpTool.DumpAll();
+                    LogInfo("DumpAll completed.");
+                }
+                catch (Exception ex)
+                {
+                    LogError($"DumpAll failed: {ex}");
+                }
             }
             if (Input.GetKey(KeyCode.LeftControl) && Input.GetKey(LoadHotkey.Value))
             {
-                LoadTool.LoadAll();
-                var localizes = GameObject.FindObjectsOfType<Localize>();
-                foreach (Localize localize in localizes)
+                LogInfo("Ctrl+F10 detected, starting LoadAll...");
+                try
                 {
-                    localize.OnLocalize();
+                    LoadTool.LoadAll();
+                    var localizes = GameObject.FindObjectsOfType<Localize>();
+                    LogInfo($"Refreshing {localizes.Length} Localize objects...");
+                    foreach (Localize localize in localizes)
+                    {
+                        localize.OnLocalize();
+                    }
+                    LogInfo("LoadAll completed.");
+                }
+                catch (Exception ex)
+                {
+                    LogError($"LoadAll failed: {ex}");
                 }
             }
         }
@@ -75,54 +152,88 @@ namespace SunHavenLocalization
         [HarmonyPostfix, HarmonyPatch(typeof(LocalizationManager), "GetTranslation")]
         public static void LocalizationManager_GetTranslation_Patch(string Term, ref string __result)
         {
-            if (LoadedLocStorage == null)
+            try
             {
-                LoadTool.LoadAll();
-            }
-            var termData = LocalizationManager.GetTermData(Term);
-            if (termData != null)
-            {
-                if (termData.TermType == eTermType.Text)
+                // 英文是源语言，不需要翻译，跳过所有逻辑避免刷 log 影响性能
+                string currentLang = LocalizationManager.CurrentLanguageCode;
+                if (currentLang == "en" || currentLang == "English")
+                    return;
+
+                // 如果已成功加载，正常工作
+                if (LoadedLocStorage != null)
                 {
-                    if (LoadedLocStorage.Storage.TryGetValue(LocalizationManager.CurrentLanguageCode, out var sheet))
+                    var termData = LocalizationManager.GetTermData(Term);
+                    if (termData != null)
                     {
-                        if (sheet.Dict.TryGetValue(Term, out var locItem))
+                        if (termData.TermType == eTermType.Text)
                         {
-                            if (!string.IsNullOrWhiteSpace(locItem.Translation))
+                            if (LoadedLocStorage.Storage.TryGetValue(LocalizationManager.CurrentLanguageCode, out var sheet))
                             {
-                                __result = locItem.Translation;
-                                if (LogGetTranslationSuccCall.Value)
+                                if (sheet.Dict.TryGetValue(Term, out var locItem))
                                 {
-                                    if (AllowMultipleTimesLogGetTranslationSuccCall.Value || !SuccKeys.Contains(Term))
+                                    if (!string.IsNullOrWhiteSpace(locItem.Translation))
                                     {
-                                        LogInfo($"GetTranslation Key:[{Term}] Translation:[{locItem.Translation}]");
-                                    }
-                                    if (!SuccKeys.Contains(Term))
-                                    {
-                                        SuccKeys.Add(Term);
-                                    }
-                                }
-                            }
-                            else
-                            {
-                                if (!string.IsNullOrWhiteSpace(__result))
-                                {
-                                    if (LogGetTranslationFailCall.Value)
-                                    {
-                                        if (AllowMultipleTimesLogGetTranslationFailCall.Value || !FailKeys.Contains(Term))
+                                        __result = locItem.Translation;
+                                        if (LogGetTranslationSuccCall.Value)
                                         {
-                                            LogWarning($"GetNoTranslation Key:[{Term}] Output:[{__result}]");
-                                            if (!FailKeys.Contains(Term))
+                                            if (AllowMultipleTimesLogGetTranslationSuccCall.Value || !SuccKeys.Contains(Term))
                                             {
-                                                FailKeys.Add(Term);
+                                                LogInfo($"GetTranslation Key:[{Term}] Translation:[{locItem.Translation}]");
+                                            }
+                                            if (!SuccKeys.Contains(Term))
+                                            {
+                                                SuccKeys.Add(Term);
+                                            }
+                                        }
+                                    }
+                                    else
+                                    {
+                                        if (!string.IsNullOrWhiteSpace(__result))
+                                        {
+                                            if (LogGetTranslationFailCall.Value)
+                                            {
+                                                if (AllowMultipleTimesLogGetTranslationFailCall.Value || !FailKeys.Contains(Term))
+                                                {
+                                                    LogWarning($"GetNoTranslation Key:[{Term}] Output:[{__result}]");
+                                                    if (!FailKeys.Contains(Term))
+                                                    {
+                                                        FailKeys.Add(Term);
+                                                    }
+                                                }
                                             }
                                         }
                                     }
                                 }
                             }
+                            else
+                            {
+                                LogWarning($"LanguageCode '{LocalizationManager.CurrentLanguageCode}' not found in LoadedLocStorage.");
+                            }
                         }
                     }
+                    return;
                 }
+
+                // 尚未加载成功 —— 每个场景只尝试一次，避免刷屏
+                if (_loadAttemptedThisScene || _loadSucceeded)
+                    return;
+
+                _loadAttemptedThisScene = true;
+                LogInfo("[GetTranslation] LocStorage not loaded yet, attempting LoadAll (once per scene)...");
+                LoadTool.LoadAll();
+                if (LoadedLocStorage != null)
+                {
+                    _loadSucceeded = true;
+                    LogInfo("[GetTranslation] LoadAll succeeded!");
+                }
+                else
+                {
+                    LogWarning("[GetTranslation] LoadAll failed (LanguageSourceAsset not ready). Will retry on next scene load.");
+                }
+            }
+            catch (Exception ex)
+            {
+                LogError($"GetTranslation_Patch exception for Term [{Term}]: {ex}");
             }
         }
 


### PR DESCRIPTION
Dear xiaoye,

我曾经为该mod提供部分翻译支持(paper)，但由于我并非一位C#开发者，由于群友有相关mod需求，我用AI辅助修复了该mod在游戏最新版本不工作的问题，及缺失的翻译文本。
使用AI辅助翻译新更新的19334条文本，已经确保基础的NPC及地名等专有名词在对话等其他地方的一致性。
目前计划为后续会接收群友反馈继续维护相关文本内容。

已经测试完成功能正常，没有明显的性能问题
https://github.com/[doublezhuang101/SunHavenLocalization](https://github.com/doublezhuang101/SunHavenLocalization)

如下为改动内容
1. 更新简体中文翻译
- 基于游戏 2026-6-23日最新版本重新导出全部文本
- 使用 AI 辅助翻译补全新增19334条目
- 人工审阅修正 NPC 人名翻译一致性
- 共 47,564 条翻译，旧版为 36,822 条

2. 修复英文模式下日志刷屏问题
当游戏语言为英文时，GetTranslation 的 Harmony Patch 会为每一个文本条目触发日志写入，一般影响性能。修复方式：在 Patch 入口处检测当前语言，若为英文（源语言）则直接 return，跳过所有字典查询和日志逻辑。

3. LanguageSource 兼容性修复
Sun Haven更新后使用 LanguageSource（MonoBehaviour），而非 LanguageSourceAsset（ScriptableObject）。新增 FindAllSourceData() 回退模式，优先搜索 LanguageSourceAsset，找不到则回退到 LanguageSource。

4. 场景加载重试防抖(该问题会导致原始mod在新版本高频load，极其影响性能 144 fps--> 10 fps)
新增 SceneManager.sceneLoaded 回调 + _loadAttemptedThisScene 标记，每个场景只尝试一次 LoadAll，避免早期初始化阶段无限重试。